### PR TITLE
Currency showing fixes.

### DIFF
--- a/src/DigitText.php
+++ b/src/DigitText.php
@@ -68,7 +68,7 @@ class DigitText
 
         $this->loadTexts();
 
-        if ($this->digit == 0) {
+        if ($this->digit == 0 && !$is_currency) {
             return $this->texts['zero'];
         }
 
@@ -124,9 +124,9 @@ class DigitText
 
         $groups = str_split($this->digitReverse((int) $this->digit), 3);
         $result = [];
-
-        for ($i = sizeof($groups) - 1; $i >= 0; $i--) {
-            if ((int) $groups[$i] > 0) {
+        $count = count($groups);
+        for ($i = $count - 1; $i >= 0; $i--) {
+            if ($i === $count - 1 || (int)$groups[$i] > 0) {
                 array_push($result, $this->digits($groups[$i], $i));
             }
         }
@@ -156,7 +156,7 @@ class DigitText
         }
 
         $digit       = explode('.', $digit);
-        $this->digit = (double) sprintf('%s.%s', intval($digit[0]), intval($digit[1]));
+        $this->digit = (double) sprintf('%s.%s', intval($digit[0]), $digit[1]);
     }
 
     /**
@@ -270,9 +270,9 @@ class DigitText
      */
     private function decline($group = 0, $digit = 0.0)
     {
-        $text    = (string) ((int) $digit);
-        $text    = (int) $text[strlen($digit) - 1];
-        $result  = '';
+        $text = (string)((int)$digit);
+        $text = (int)$text[strlen($digit) - 1];
+        $result = '';
         $divider = ($this->lang == 'de' ? '' : ' ');
 
         switch ($group) {
@@ -329,18 +329,11 @@ class DigitText
                 $this->texts['currency']['int'],
             ]);
 
-            if ($this->surplus > 0) {
-                $result .= implode(' ', [
-                    '',
-                    $this->surplus,
-                    $this->texts['currency']['fraction'],
-                ]);
-            } else {
-                $result .= implode(' ', [
-                    ' 00',
-                    $this->texts['currency']['fraction'],
-                ]);
-            }
+            $result .= implode(' ', [
+                '',
+                str_pad((string)$this->surplus, $this->texts['currency']['precision'], '0', STR_PAD_RIGHT),
+                $this->texts['currency']['fraction'],
+            ]);
         }
 
         return $result;

--- a/src/DigitText.php
+++ b/src/DigitText.php
@@ -124,9 +124,9 @@ class DigitText
 
         $groups = str_split($this->digitReverse((int) $this->digit), 3);
         $result = [];
-        $count = count($groups);
+        $count  = count($groups);
         for ($i = $count - 1; $i >= 0; $i--) {
-            if ($i === $count - 1 || (int)$groups[$i] > 0) {
+            if ($i === $count - 1 || (int) $groups[$i] > 0) {
                 array_push($result, $this->digits($groups[$i], $i));
             }
         }
@@ -270,9 +270,9 @@ class DigitText
      */
     private function decline($group = 0, $digit = 0.0)
     {
-        $text = (string)((int)$digit);
-        $text = (int)$text[strlen($digit) - 1];
-        $result = '';
+        $text    = (string) ((int) $digit);
+        $text    = (int) $text[strlen($digit) - 1];
+        $result  = '';
         $divider = ($this->lang == 'de' ? '' : ' ');
 
         switch ($group) {
@@ -331,7 +331,7 @@ class DigitText
 
             $result .= implode(' ', [
                 '',
-                str_pad((string)$this->surplus, $this->texts['currency']['precision'], '0', STR_PAD_RIGHT),
+                str_pad((string) $this->surplus, $this->texts['currency']['precision'], '0', STR_PAD_RIGHT),
                 $this->texts['currency']['fraction'],
             ]);
         }

--- a/src/lang/de.php
+++ b/src/lang/de.php
@@ -100,6 +100,7 @@ return [
         'int'      => 'Mark',
         'fraction' => 'cent',
         'position' => 'after',
+        'precision'=> 2,
     ],
 
     'zero' => 'null',

--- a/src/lang/en.php
+++ b/src/lang/en.php
@@ -100,6 +100,7 @@ return [
         'int'      => 'dollars',
         'fraction' => 'cents',
         'position' => 'after',
+        'precision'=> 2,
     ],
 
     'zero' => 'zero',

--- a/src/lang/ru.php
+++ b/src/lang/ru.php
@@ -100,6 +100,7 @@ return [
         'int'      => 'руб',
         'fraction' => 'коп',
         'position' => 'after',
+        'precision'=> 1,
     ],
 
     'zero' => 'ноль',

--- a/src/lang/uk.php
+++ b/src/lang/uk.php
@@ -100,6 +100,7 @@ return [
         'int'      => 'грн',
         'fraction' => 'коп',
         'position' => 'after',
+        'precision'=> 2,
     ],
 
     'zero' => 'нуль',

--- a/tests/DigitTextTest.php
+++ b/tests/DigitTextTest.php
@@ -20,6 +20,19 @@ class DigitTextTest extends TestCase
     }
 
     /**
+     * Currency text testing.
+     */
+    public function testCurrency()
+    {
+        $this->assertEquals($this->service->get(64, 'ru', true), 'шестьдесят четыре руб 00 коп');
+        $this->assertEquals($this->service->get(64.01, 'ru', true), 'шестьдесят четыре руб 01 коп');
+        $this->assertEquals($this->service->get(64.10, 'ru', true), 'шестьдесят четыре руб 10 коп');
+        $this->assertEquals($this->service->get(0, 'ru', true), 'ноль руб 00 коп');
+        $this->assertEquals($this->service->get(0.01, 'ru', true), 'ноль руб 01 коп');
+        $this->assertEquals($this->service->get(0.10, 'ru', true), 'ноль руб 10 коп');
+    }
+
+    /**
      * Russian localization testing.
      */
     public function testRu()


### PR DESCRIPTION
Always display the first group. 
Use precision when displaying fractional parts. 
Zero showing with fractional. 
Fixed loss digits on fractional part.
